### PR TITLE
Changed config path and validated yaml

### DIFF
--- a/vendor/config.yaml
+++ b/vendor/config.yaml
@@ -1,6 +1,6 @@
 ---
-api_docs: ../../docs.yaml
+api_docs: docs.yaml
 api_template_directory: ../api
 api_template_file: ../api/template.mdx
-api_build_to: ../../docs/products/zander/api
+api_build_to: ../docs/products/zander/api
 api_section_label: API Endpoints

--- a/vendor/docs.yaml
+++ b/vendor/docs.yaml
@@ -32,7 +32,7 @@ announcement:
           type: string
           info: User initiating the action.
           optional: false
-         enabled:
+        enabled:
           type: boolean
           info: 1 if the announcement is enabled, 0 if disabled.
           optional: false
@@ -404,7 +404,7 @@ user:
 web:
   sidebar: Website
   files:
-   - create.mdx:
+  - create.mdx:
       route: web/register/create
       method: POST
       privileged: true
@@ -427,7 +427,7 @@ web:
           type: string
           info: The same as password hopefully.
           optional: false
-   - login.mdx:
+  - login.mdx:
       route: web/login
       method: POST
       privileged: true
@@ -446,7 +446,7 @@ web:
           type: string
           info: Password that user has inserted.
           optional: false
-   - logout.mdx:
+  - logout.mdx:
       route: web/logout
       method: GET
       privileged: true


### PR DESCRIPTION
`config.yaml`'s working directory is `./vendor` so paths should be relative to that. Secondly, some areas of docs.yaml were invalid with their indentation. Turning on whitespace characters and yaml linting found the errors straight away.